### PR TITLE
Avoid reading .nvmrc during action setup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,8 +56,12 @@ install_node()
     fi
     bash nvm-install.sh
     rm nvm-install.sh
+
+    # Avoid picking up `.nvmrc` from the repository
+    pushd / >/dev/null
     . ~/.nvm/nvm.sh
     nvm install "$NODEVER"
+    popd >/dev/null
 }
 
 install_slither()


### PR DESCRIPTION
This moves PWD temporarily to `/`, to avoid picking up any problematic `.nvmrc` which may
be present in the working directory.