### PR TITLE
Drop extra crytic-compile call

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -141,8 +141,6 @@ if [[ -n "$SLITHERCONF" ]]; then
     CONFIGFLAG="--config-file=$SLITHERCONF"
 fi
 
-crytic-compile "$TARGET" $IGNORECOMPILEFLAG
-
 if [[ -z "$SLITHERARGS" ]]; then
     slither "$TARGET" $SARIFFLAG $IGNORECOMPILEFLAG $CONFIGFLAG
 else


### PR DESCRIPTION
This extra call is breaking some use-cases that require custom crytic-compile
options, as there is no way to pass them. As slither will invoke
the compilation by itself when needed, this extra call is not really
needed and should be safe to drop.

Fixes: #3, #4