### PR TITLE
Create symlink from host-path to container-path to enhance compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,12 @@ inputs:
     description: 'Whether to ignore the compilation step when running crytic-compile and Slither.'
     default: false
     type: boolean
+  internal-github-workspace:
+    # Do not set manually. This is a hacky way to pass the host workspace to inside the action
+    # This is used to improve compatibility when using ignore-compile.
+    # GitHub rewrites the argument if it is passed directly, to we use toJSON to "transform"
+    # it and avoid the remapping done by GitHub Actions.
+    default: ${{ toJSON(github.workspace) }}
 outputs:
   sarif:
     description: 'If produced, the path of the SARIF file, relative to the repo root.'

--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,9 @@ inputs:
     default: false
     type: boolean
   internal-github-workspace:
-    # Do not set manually. This is a hacky way to pass the host workspace to inside the action
-    # This is used to improve compatibility when using ignore-compile.
-    # GitHub rewrites the argument if it is passed directly, to we use toJSON to "transform"
+    # Do not set manually. This is a hacky way to pass the host workspace path to inside the action
+    # This is used to improve compatibility when using `ignore-compile`.
+    # GitHub rewrites the argument if it is passed directly, so we use toJSON to "transform"
     # it and avoid the remapping done by GitHub Actions.
     default: ${{ toJSON(github.workspace) }}
 outputs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,16 @@ SLITHERARGS="$(get INPUT_SLITHER-ARGS)"
 SLITHERCONF="$(get INPUT_SLITHER-CONFIG)"
 IGNORECOMPILE="$(get INPUT_IGNORE-COMPILE)"
 
+compatibility_link()
+{
+    HOST_GITHUB_WORKSPACE="$(get INPUT_INTERNAL-GITHUB-WORKSPACE | tr -d \")"
+    if [[ -d "$GITHUB_WORKSPACE" ]]; then
+        mkdir -p "$(dirname "$HOST_GITHUB_WORKSPACE")"
+        ln -s "$GITHUB_WORKSPACE" "$HOST_GITHUB_WORKSPACE"
+        echo "[-] Applied compatibility link: $HOST_GITHUB_WORKSPACE -> $GITHUB_WORKSPACE"
+    fi
+}
+
 install_solc()
 {
     if [[ -z "$SOLCVER" ]]; then
@@ -153,6 +163,7 @@ if [[ -z "$IGNORECOMPILE" || $IGNORECOMPILE =~ ^[Ff]alse$ ]]; then
     install_foundry
     install_deps
 else
+    compatibility_link
     IGNORECOMPILEFLAG="--ignore-compile"
 fi
 


### PR DESCRIPTION
If a project is built outside of the container and the build artifacts
contain absolute paths, this can cause issues as the folder "moves" between
build and analysis time due to the Slither action running inside a Docker
container. This creates a symlink from the old path to the new one to
try and avoid any issues that might arise from this path change.