### PR TITLE
Add stdout output

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,10 +328,10 @@ jobs:
         ignore-compile: true
 ```
 
-## Example workflow: markdown report
+## Example workflow: Markdown report
 
 The following GitHub Actions workflow example will create/update pull requests
-with the contents of Slither's markdown report. Useful for when [GitHub Advanced
+with the contents of Slither's Markdown report. Useful for when [GitHub Advanced
 Security](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security)
 (required for the SARIF feature) is unavailable.
 
@@ -346,23 +346,20 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
     - name: Run Slither
-      uses: crytic/slither-action@main
-      continue-on-error: true
+      uses: crytic/slither-action@v0.2.0
       id: slither
       with:
         node-version: 16
+        fail-on: none
         slither-args: --checklist --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
 
     - name: Create/update checklist as PR comment
-      uses: actions/github-script@v5.1.0
+      uses: actions/github-script@v6
       if: github.event_name == 'pull_request'
       with:
         script: |

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,8 @@ inputs:
 outputs:
   sarif:
     description: 'If produced, the path of the SARIF file, relative to the repo root.'
+  stdout:
+    description: 'Standard output from Slither. Works well when passing `--checklist` in slither-args.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ SARIFOUT="$4"
 SLITHERVER="$5"
 SLITHERARGS="$(get INPUT_SLITHER-ARGS)"
 SLITHERCONF="$(get INPUT_SLITHER-CONFIG)"
+STDOUTFILE="/tmp/slither-stdout"
 IGNORECOMPILE="$(get INPUT_IGNORE-COMPILE)"
 
 compatibility_link()
@@ -181,8 +182,15 @@ if [[ -n "$SLITHERCONF" ]]; then
 fi
 
 if [[ -z "$SLITHERARGS" ]]; then
-    slither "$TARGET" $SARIFFLAG $IGNORECOMPILEFLAG $CONFIGFLAG
+    slither "$TARGET" $SARIFFLAG $IGNORECOMPILEFLAG $CONFIGFLAG | tee "$STDOUTFILE"
 else
     echo "[-] SLITHERARGS provided. Running slither with extra arguments"
-    printf "%s\n" "$SLITHERARGS" | xargs slither "$TARGET" $SARIFFLAG $IGNORECOMPILEFLAG $CONFIGFLAG
+    printf "%s\n" "$SLITHERARGS" | xargs slither "$TARGET" $SARIFFLAG $IGNORECOMPILEFLAG $CONFIGFLAG | tee "$STDOUTFILE"
 fi
+
+# https://github.community/t/set-output-truncates-multiline-strings/16852/3
+STDOUT="$(< $STDOUTFILE)"
+STDOUT="${STDOUT//'%'/'%25'}"
+STDOUT="${STDOUT//$'\n'/'%0A'}"
+STDOUT="${STDOUT//$'\r'/'%0D'}"
+echo "::set-output name=stdout::$STDOUT"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,10 @@ get() {
     env | sed -n "s/^$1=\(.*\)/\1/;T;p"
 }
 
+random_string() {
+    echo "$RANDOM $RANDOM $RANDOM $RANDOM $RANDOM" | md5sum | head -c 20
+}
+
 version_lte() {
     printf '%s\n%s\n' "$1" "$2" | sort -C -V
 }
@@ -265,9 +269,5 @@ else
     printf "%s\n" "$SLITHERARGS" | xargs slither "$TARGET" $SARIFFLAG $IGNORECOMPILEFLAG $FAILONFLAG $CONFIGFLAG | tee "$STDOUTFILE"
 fi
 
-# https://github.community/t/set-output-truncates-multiline-strings/16852/3
-STDOUT="$(< $STDOUTFILE)"
-STDOUT="${STDOUT//'%'/'%25'}"
-STDOUT="${STDOUT//$'\n'/'%0A'}"
-STDOUT="${STDOUT//$'\r'/'%0D'}"
-echo "::set-output name=stdout::$STDOUT"
+DELIMITER="$(random_string)"
+{ echo "stdout<<$DELIMITER"; cat "$STDOUTFILE"; echo -e "\n$DELIMITER"; } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Unfortunately [GitHub Advanced Security](https://docs.github.com/en/get-started/learning-about-github/about-github-advanced-security) (for the SARIF feature) is unavailable for private repos on GitHub.com. As an alternative, Slither's markdown report can be used.

This sets `outputs.stdout` (which is required to be a single-line string) and adds example usage to the readme. See https://github.com/tlvince/hardhat-project/pull/1#issuecomment-1147434360 to see how it looks.