### PR TITLE
Add a way to install Slither plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobs:
 | `slither-args`   | Extra arguments to pass to Slither.
 | `slither-config` | The path to the Slither configuration file. By default, `./slither.config.json` is used if present. See [Configuration file](https://github.com/crytic/slither/wiki/Usage#configuration-file).
 | `slither-version`| The version of slither-analyzer to use. By default, the latest release in PyPI is used.
+| `slither-plugins`| A `requirements.txt` file to install with `pip` alongside Slither. Useful to install custom plugins.
 | `solc-version`   | The version of `solc` to use. If this field is not set, the version will be guessed from project metadata. **This only has an effect if you are not using a compilation framework for your project** -- i.e., if `target` is a standalone `.sol` file.
 | `target`         | The path to the root of the project to be analyzed by Slither. It can be a directory or a file, and it defaults to the repo root.
 
@@ -400,4 +401,33 @@ module.exports = async ({ github, context, header, body }) => {
       : { issue_number: context.payload.number }),
   });
 };
+```
+
+### Example workflow: external plugins
+
+The following is a modification of the "simple action" example from earlier.
+This example uses the `slither-plugins` property to point to a pip
+[requirements](https://pip.pypa.io/en/stable/reference/requirements-file-format/)
+file that gets installed alongside Slither. In this example, the requirements
+file installs the example plugin provided in the Slither repository, but this
+can be modified to install extra third-party or in-house detectors.
+
+```yaml
+name: Slither Analysis
+on: [push]
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crytic/slither-action@v0.3.2
+        with:
+          target: 'src/'
+          slither-plugins: requirements-plugins.txt
+```
+
+`requirements-plugins.txt`:
+
+```text
+slither_my_plugin @ git+https://github.com/crytic/slither#egg=slither_my_plugin&subdirectory=plugin_example
 ```

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,8 @@ inputs:
     description: 'The path to the Slither configuration file. By default, `./slither.config.json` is used if present.'
   slither-version:
     description: 'The version of slither-analyzer to use. By default, the latest release in PyPI is used.'
+  slither-plugins:
+    description: 'A requirements.txt file to install alongside Slither. Useful to install custom plugins.'
   ignore-compile:
     description: 'Whether to ignore the compilation step when running crytic-compile and Slither.'
     default: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,6 +21,7 @@ SARIFOUT="$4"
 SLITHERVER="$5"
 SLITHERARGS="$(get INPUT_SLITHER-ARGS)"
 SLITHERCONF="$(get INPUT_SLITHER-CONFIG)"
+SLITHERPLUGINS="$(get INPUT_SLITHER-PLUGINS)"
 STDOUTFILE="/tmp/slither-stdout"
 IGNORECOMPILE="$(get INPUT_IGNORE-COMPILE)"
 
@@ -185,6 +186,13 @@ install_slither()
     export PATH="/opt/slither/bin:$PATH"
     pip3 install wheel
     pip3 install "$SLITHERPKG"
+
+    if [[ -n "$SLITHERPLUGINS" ]]; then
+        echo "[-] Slither plugins provided, installing them"
+        pushd "$(dirname "$SLITHERPLUGINS")" >/dev/null
+        pip3 install -r "$(basename "$SLITHERPLUGINS")"
+        popd >/dev/null
+    fi
 }
 
 install_deps()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -248,6 +248,12 @@ install_deps()
     fi
 }
 
+output_stdout()
+{
+    DELIMITER="$(random_string)"
+    { echo "stdout<<$DELIMITER"; cat "$STDOUTFILE"; echo -e "\n$DELIMITER"; } >> "$GITHUB_OUTPUT"
+}
+
 compatibility_link
 install_slither
 
@@ -276,12 +282,11 @@ fi
 
 FAILONFLAG="$(fail_on_flags)"
 
+trap "output_stdout" EXIT
+
 if [[ -z "$SLITHERARGS" ]]; then
     slither "$TARGET" $SARIFFLAG $IGNORECOMPILEFLAG $FAILONFLAG $CONFIGFLAG | tee "$STDOUTFILE"
 else
     echo "[-] SLITHERARGS provided. Running slither with extra arguments"
     printf "%s\n" "$SLITHERARGS" | xargs slither "$TARGET" $SARIFFLAG $IGNORECOMPILEFLAG $FAILONFLAG $CONFIGFLAG | tee "$STDOUTFILE"
 fi
-
-DELIMITER="$(random_string)"
-{ echo "stdout<<$DELIMITER"; cat "$STDOUTFILE"; echo -e "\n$DELIMITER"; } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This adds an extra option, `slither-plugins`, that lets users provide
a requirements.txt file to be installed alongside Slither. This can
be used to install Slither plugins.

Fixes: #16