### PR TITLE
Protect against accidental SOLC_VERSION clash from workflow

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,11 @@ SLITHERARGS="$(get INPUT_SLITHER-ARGS)"
 SLITHERCONF="$(get INPUT_SLITHER-CONFIG)"
 IGNORECOMPILE="$(get INPUT_IGNORE-COMPILE)"
 
+# #19 - an user may set SOLC_VERSION in the workflow and cause problems here.
+# Make sure it's unset. If you need to use a different solc version, override
+# it with the `solc-version` action option.
+unset SOLC_VERSION
+
 compatibility_link()
 {
     HOST_GITHUB_WORKSPACE="$(get INPUT_INTERNAL-GITHUB-WORKSPACE | tr -d \")"


### PR DESCRIPTION
Users may set SOLC_VERSION in the workflow and cause hard-to-diagnose
problems in the action (see crytic/slither-action#19). To avoid that
from happening, unset SOLC_VERSION early on. If the user desires
to change the solc version, they can always use the `solc-version`
action option.

Closes: #19