### PR TITLE
chore(entrypoint.sh): better solc detection

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ install_solc()
             SOLCVER="$(grep --no-filename '^pragma solidity' "$TARGET" | cut -d' ' -f3)"
         else
             pushd "$TARGET" >/dev/null
-            SOLCVER="$(grep --no-filename '^pragma solidity' -r --include \*.sol --exclude-dir node_modules | \
+            SOLCVER="$(grep --no-filename '^pragma solidity' -r --include \*.sol --exclude-dir node_modules --exclude-dir dist | \
                        cut -d' ' -f3 | sort | uniq -c | sort -n | tail -1 | tr -s ' ' | cut -d' ' -f3)"
             popd >/dev/null
         fi


### PR DESCRIPTION
It is a common practice to set `./dist` as an `outDir` compilation option in `tsconfig.json` (see e.g. [here](https://github.com/dethcrypto/TypeChain/tree/master/packages/hardhat) or [here](https://stermi.medium.com/how-to-deploy-your-first-smart-contract-on-ethereum-with-solidity-and-hardhat-22f21d31096e)). 

It is also unlikely that `dist` folder would contain non-autogenerated files.

We are reusing `dist` as an output destination for autogerenated, hardhat-flattened contracts as well and would like to exclude them from the analysis for solc-detection since flattened contracts also include all the dependencies, similarly to `node_modules`.

There are two ways of solving the problem:
* a simple fix to add `dist` together with `node_modules` (proposed in this PR)
* add another configuration option to allow this list of excludes to be user-defined.