### PR TITLE
Add pnpm support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -123,6 +123,8 @@ install_deps()
         elif [[ -f pnpm-lock.yaml ]]; then
             echo "[-] Installing dependencies from pnpm-lock.yaml"
             npm install -g pnpm
+            mkdir .pnpm-store
+            pnpm config set store-dir .pnpm-store
             pnpm install --frozen-lockfile
         elif [[ -f package.json ]]; then
             echo "[-] Did not detect a package-lock.json, yarn.lock, or pnpm-lock.yaml in $TARGET, consider locking your dependencies!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -120,8 +120,12 @@ install_deps()
             echo "[-] Installing dependencies from yarn.lock"
             npm install -g yarn
             yarn install --frozen-lockfile
+        elif [[ -f pnpm-lock.yaml ]]; then
+            echo "[-] Installing dependencies from pnpm-lock.yaml"
+            npm install -g pnpm
+            pnpm install --frozen-lockfile
         elif [[ -f package.json ]]; then
-            echo "[-] Did not detect a package-lock.json or yarn.lock in $TARGET, consider locking your dependencies!"
+            echo "[-] Did not detect a package-lock.json, yarn.lock, or pnpm-lock.yaml in $TARGET, consider locking your dependencies!"
             echo "[-] Proceeding with 'npm i' to install dependencies"
             npm i
         else


### PR DESCRIPTION
Add PNPM support to the GH Action.

I had to explicitly call `pnpm config set store-dir` to avoid a folder permissions issue with whatever the default `store-dir` location is.