### PR TITLE
Adds support for pnpn repositories

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -120,6 +120,10 @@ install_deps()
             echo "[-] Installing dependencies from yarn.lock"
             npm install -g yarn
             yarn install --frozen-lockfile
+        elif [[ -f pnpm-lock.yaml ]]; then
+            echo "[-] Installing dependencies from pnpm-lock-yaml"
+            npm install -g pnpm
+            pnpm install
         elif [[ -f package.json ]]; then
             echo "[-] Did not detect a package-lock.json or yarn.lock in $TARGET, consider locking your dependencies!"
             echo "[-] Proceeding with 'npm i' to install dependencies"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -125,7 +125,7 @@ install_deps()
             npm install -g pnpm
             pnpm install
         elif [[ -f package.json ]]; then
-            echo "[-] Did not detect a package-lock.json or yarn.lock in $TARGET, consider locking your dependencies!"
+            echo "[-] Did not detect a package-lock.json or yarn.lock or pnpm-lock.yaml in $TARGET, consider locking your dependencies!"
             echo "[-] Proceeding with 'npm i' to install dependencies"
             npm i
         else


### PR DESCRIPTION
We use a pnpm monorepo for our smart contracts. Previously this action looked for yarn or npm, this PR adds a check for `pnpm-lock.yaml` and will pnpm install dependencies.