### PR TITLE
Enable pipefail

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -e -o pipefail
 
 # smoelius: `get` works for non-standard variable names like `INPUT_CORPUS-DIR`.
 get() {


### PR DESCRIPTION
Slither is now invoked as part of a series of piped commands. However the default shell behavior is to mask any error reported if the last command succeeds. This causes failures in slither to be masked unintentionally. Enable pipefail to make the pipeline of commands fail instead, restoring the previous behavior.