### PR TITLE
Improve markdown checklist example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,11 +361,13 @@ jobs:
     - name: Create/update checklist as PR comment
       uses: actions/github-script@v6
       if: github.event_name == 'pull_request'
+      env:
+        REPORT: ${{ steps.slither.outputs.stdout }}
       with:
         script: |
           const script = require('.github/scripts/comment')
           const header = '# Slither report'
-          const body = `${{ steps.slither.outputs.stdout }}`
+          const body = process.env.REPORT
           await script({ github, context, header, body })
 ```
 


### PR DESCRIPTION
The example did not escape the markdown document correctly. Use an environment variable instead of direct string interpolation to consume the document safely in the github-script action.

Closes #59