### PR TITLE
Rework Foundry installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
 |------------------|------------
 | `ignore-compile` | If set to true, the Slither action will not attempt to compile the project. False by default. See [Advanced compilation](#advanced-compilation).
 | `fail-on`        | Cause the action to fail if Slither finds any issue of this severity or higher. See [action fail behavior](#action-fail-behavior).
+| `foundry-version`| The version of `forge` to use, if required. If this field is not set, the `nightly` version will be used.
 | `node-version`   | The version of `node` to use. If this field is not set, the latest version will be used.
 | `sarif`          | If provided, the path of the SARIF file to produce, relative to the repo root (see [Github Code Scanning integration](#github-code-scanning-integration)).
 | `slither-args`   | Extra arguments to pass to Slither.

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'The version of solc to use. Should be autodetected, but may be specified manually.'
   node-version:
     description: 'The version of node to use.'
+  foundry-version:
+    description: 'The version of foundry to install, if required. By default, nightly is used.'
+    default: nightly
+    type: string
   target:
     description: 'The path of the project that Slither should analyze, relative to the repo root.'
     default: .


### PR DESCRIPTION
The action will now attempt to run `foundryup` multiple times in an attempt to make the installation more reliable. A new action parameter, `foundry-version`, is now available as well, so users can lock in a known-working Foundry version if needed.

Closes #69