### PR TITLE
Always create compatibility symlink

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -240,6 +240,7 @@ install_deps()
     fi
 }
 
+compatibility_link
 install_slither
 
 IGNORECOMPILEFLAG=
@@ -249,7 +250,6 @@ if [[ -z "$IGNORECOMPILE" || $IGNORECOMPILE =~ ^[Ff]alse$ ]]; then
     install_foundry
     install_deps
 else
-    compatibility_link
     IGNORECOMPILEFLAG="--ignore-compile"
 fi
 


### PR DESCRIPTION
This can still be useful when part of the codebase is built outside of the container.

Fixes #75