### PR TITLE
fix(action): output checklist

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,8 @@ outputs:
     description: 'If produced, the path of the SARIF file, relative to the repo root.'
   stdout:
     description: 'Standard output from Slither. Works well when passing `--checklist` in slither-args.'
+   checklist:
+     description: 'Generate a markdown page with the detector results'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
Slither implies that the GitHub Action supports checklist output:


```console
Checklist (consider using https://github.com/crytic/slither-action):
  --checklist           Generate a markdown page with the detector results
  --checklist-limit CHECKLIST_LIMIT
                        Limit the number of results per detector in the markdown file
  --markdown-root MARKDOWN_ROOT
                        URL for markdown generation
```

This PR does not implement checklist explicitly, as you can already get it by passing in the additional arguments option. 

Adding the needed definition in the `entrypoint.sh` script would be explicit.